### PR TITLE
Add setup script for Node packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ Frontend for Wrenfield Consulting. We build systems, structure, and digital tool
 
 ## Getting Started
 
-First, install the dependencies:
+First, install the dependencies by running the provided setup script:
+
+```bash
+./setup.sh
+```
+
+The script uses `npm ci` to install all packages. If you prefer to install
+manually, you can run one of the standard commands:
 
 ```bash
 npm install

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+npm ci


### PR DESCRIPTION
## Summary
- add a `setup.sh` script that installs packages with `npm ci`
- document the script in the Getting Started instructions

## Testing
- `bash -n setup.sh`